### PR TITLE
fix authority normalization

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -88,6 +88,9 @@ const resolveReference = (strategy) => (reference, base) => {
 
     if (resolvedComponents.authority === undefined) {
       resolvedComponents.authority = baseComponents.authority;
+      resolvedComponents.userinfo = baseComponents.userinfo;
+      resolvedComponents.host = baseComponents.host;
+      resolvedComponents.port = baseComponents.port;
 
       if (resolvedComponents.path === "") {
         resolvedComponents.path = baseComponents.path;
@@ -165,7 +168,10 @@ const getSegment = (path) => {
 /** @type (strategy: Strategy, components: API.IdentifierComponents) => string */
 const composeIdentifier = (strategy, components) => {
   let resolved = components.scheme.toLowerCase() + ":";
-  resolved += components.authority === undefined ? "" : "//" + components.authority.toLowerCase();
+  resolved += components.authority === undefined ? "" : "//"
+    + (components.userinfo === undefined ? "" : components.userinfo + "@")
+    + components.host.toLowerCase()
+    + (components.port === undefined ? "" : ":" + components.port);
   resolved += strategy.normalizePath(components.path);
   resolved += components.query === undefined ? "" : "?" + strategy.normalizeQuery(components.query);
   resolved += components.fragment === undefined ? "" : "#" + strategy.normalizeFragment(components.fragment);

--- a/lib/resolve-reference.test.js
+++ b/lib/resolve-reference.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-import { resolveIri } from "./index.js";
+import { normalizeUri, resolveIri } from "./index.js";
 
 
 const resolveTests = [
@@ -63,5 +63,15 @@ describe("resolveReference", () => {
       const subject = resolveIri(iriReference, baseIri);
       expect(subject).to.equal(expected);
     });
+  });
+});
+
+describe("normalizeUri", () => {
+  test("normalize userinfo", () => {
+    const input = "Https://JDesrosiers@Example.com";
+    const expected = "https://JDesrosiers@example.com";
+    const actual = normalizeUri(input);
+
+    expect(actual).to.equal(expected);
   });
 });

--- a/lib/resolve-reference.test.js
+++ b/lib/resolve-reference.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-import { normalizeUri, resolveIri } from "./index.js";
+import { resolveIri } from "./index.js";
 
 
 const resolveTests = [
@@ -54,7 +54,8 @@ const resolveTests = [
   ["http://example.com/b%2Fc/d/e", "", "http://example.com/b%2Fc/d/e"], // Necessary encoding segment
   ["http://example.com/b%2fc/d/e", "", "http://example.com/b%2Fc/d/e"], // Case normalization of encoding segment
   ["http://example.com/b?c%2Fd%3Fe", "", "http://example.com/b?c/d?e"], // Unnecessary encoding query
-  ["http://example.com/b", "#c%2Fd%3Fe", "http://example.com/b#c/d?e"] // Unnecessary encoding fragment
+  ["http://example.com/b", "#c%2Fd%3Fe", "http://example.com/b#c/d?e"], // Unnecessary encoding fragment
+  ["Https://JDesrosiers@Example.com", "", "https://JDesrosiers@example.com"] // Case normalization of authority
 ];
 
 describe("resolveReference", () => {
@@ -63,15 +64,5 @@ describe("resolveReference", () => {
       const subject = resolveIri(iriReference, baseIri);
       expect(subject).to.equal(expected);
     });
-  });
-});
-
-describe("normalizeUri", () => {
-  test("normalize userinfo", () => {
-    const input = "Https://JDesrosiers@Example.com";
-    const expected = "https://JDesrosiers@example.com";
-    const actual = normalizeUri(input);
-
-    expect(actual).to.equal(expected);
   });
 });


### PR DESCRIPTION
## Description
The normalization process was lowercasing the entire authority component, which incorrectly lowercased the userinfo part.

FIXES : #5 

### Changes

- Updated `resolveReference` to copy `userinfo`,` host`, and `port` when the base authority is used.
- Updated `composeIdentifier` to build the authority string from components, lowercasing only the host.
